### PR TITLE
Choose the right network during runtime, not build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ The default derivation path for the wallet keypair is m/44'/9000'/0'/0/0. This i
 # Licence
 
 [MIT](LICENSE.md)
+
+a

--- a/lib/adapter/router.js
+++ b/lib/adapter/router.js
@@ -5,9 +5,6 @@
   replacements for one another.
 */
 
-// const network = 'mainnet'
-const network = 'fuji'
-
 const networks = require('../networks')
 const Axios = require('axios')
 
@@ -106,10 +103,15 @@ class AdapterRouter {
         throw new Error('baseTx must be a string')
       }
 
+      let explorer = networks.mainnet.explorer
+      if (this.ava.getNetworkID() === networks.fuji.networkID) {
+        explorer = networks.fuji.explorer
+      }
+
       if (this.interface === 'rest-api') {
         const txid = await this.xchain.issueTx(baseTx)
 
-        console.log(`https://${networks[network].explorer}/tx/${txid}`)
+        console.log(`https://${explorer}/tx/${txid}`)
 
         return txid
       }
@@ -127,14 +129,18 @@ class AdapterRouter {
   }
 
   // Retrieve the most recent transactions for an address from Avascan.
-  async getTransactions (address) {
+  async getTransactions (address) { // network can be also 'fuji'
     try {
       if (typeof address !== 'string' || !address.length) {
         throw new Error('The provided avax address is not valid')
       }
 
+      let explorerAPI = networks.mainnet.explorerAPI
+      if (this.ava.getNetworkID() === networks.fuji.networkID) {
+        explorerAPI = networks.fuji.explorerAPI
+      }
       if (this.interface === 'rest-api') {
-        const query = `https://${networks[network].explorerAPI}/v2/transactions?address=${address}&sort=timestamp-desc`
+        const query = `https://${explorerAPI}/v2/transactions?address=${address}&sort=timestamp-desc`
         const request = await this.axios.post(query)
 
         if (request.status >= 400) {

--- a/lib/send.js
+++ b/lib/send.js
@@ -1,13 +1,11 @@
 const avm = require('avalanche/dist/apis/avm')
 const { KeyChain } = require('avalanche/dist/apis/evm')
 
-const network = 'mainnet'
-// const network = 'fuji'
-const networks = require('./networks')
+const networks = require('../lib/networks')
 
 class Send {
   constructor (localConfig = {}) {
-    this.avaxID = networks[network].avaxID
+    this.avaxID = localConfig.avaxID || networks.mainnet.avaxID
 
     // Dependency injection.
     this.ava = localConfig.ava


### PR DESCRIPTION
Building of all files inside the `lib/` folder should not depend from the network. With putting `const network ='...'` inside the library sources, when it is build for one target, it will not work on other. Fixed this - now the build `dist/` file will work with both mainnet and testnet. Choosing will be during run-time (as it is demonstrated in the examples).